### PR TITLE
Update the syntax for pre/post conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Ocaml-cram supports non-deterministic outputs:
 
 ```
   $ <command>
-<-- --non-deterministic
+<-- non-deterministic
   <output>
 ```
 
@@ -55,7 +55,7 @@ Ocaml-cram supports non-deterministic outputs:
 
 ```
   $ <command>
-<-- --non-deterministic [skip]
+<-- non-deterministic [skip]
   <output>
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ supports the following syntax:
 - Lines beginning with two spaces are considered command *output*.
 - Command outputs can contains *ellipsis*: `...`. These will
   match any possible outputs (on zero, one or multiple lines).
-- Lines starting by `%%` are command *pre-conditions*; they will
+- Lines starting by `<--` are command *pre-conditions*; they will
   determine the conditions where the command is run. Currently, only
   non-deterministic modes are supported as pre-conditions (see below).
-- Lines starting by `@@` are command *post-conditions*. Currently,
+- Lines starting by `-->` are command *post-conditions*. Currently,
   only exit codes are supported as post-conditions (see below).
 - Anything else is a comment. It is not possible to put comments
   in the middle of an output as it is not clear what should be done
@@ -40,7 +40,7 @@ Ocaml-cram supports non-deterministic outputs:
 
 ```
   $ <command>
-%% --non-deterministic
+<-- --non-deterministic
   <output>
 ```
 
@@ -55,7 +55,7 @@ Ocaml-cram supports non-deterministic outputs:
 
 ```
   $ <command>
-%% --non-deterministic [skip]
+<-- --non-deterministic [skip]
   <output>
 ```
 
@@ -69,7 +69,7 @@ Ocaml-cram tests exit codes:
 ```
   $ <command>
   <output>
-@@ exit 10
+--> exit 10
 ```
 
 If `<command>` does not exit with code 10, then `cram <file>` will

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -113,10 +113,10 @@ let pp_line ?(hide=false) ppf line =
   | `Part s           -> Fmt.pf ppf "### %s\n" s
   | `Command c        -> Fmt.pf ppf "  $ %a\n" pp_command c
   | `Ellipsis         -> Fmt.pf ppf "  ...\n"
-  | `Non_det `Output  -> pp_meta ppf "%%%% --non-deterministic\n"
-  | `Non_det `Command -> pp_meta ppf "%%%% --non-deterministic [skip]\n"
+  | `Non_det `Output  -> pp_meta ppf "<-- --non-deterministic\n"
+  | `Non_det `Command -> pp_meta ppf "<-- --non-deterministic [skip]\n"
   | `Comment s        -> pp_meta ppf "%s\n" s
-  | `Exit i           -> pp_meta ppf "@@@@ exit %d" i
+  | `Exit i           -> pp_meta ppf "--> exit %d" i
 
 let pp ?hide ppf t =
   List.iter (function

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -116,8 +116,8 @@ let pp_line ?(hide=false) ppf line =
   | `Part s           -> Fmt.pf ppf "### %s\n" s
   | `Command c        -> Fmt.pf ppf "  $ %a\n" pp_command c
   | `Ellipsis         -> Fmt.pf ppf "  ...\n"
-  | `Non_det `Output  -> pp_meta ppf "<-- --non-deterministic\n"
-  | `Non_det `Command -> pp_meta ppf "<-- --non-deterministic [skip]\n"
+  | `Non_det `Output  -> pp_meta ppf "<-- non-deterministic\n"
+  | `Non_det `Command -> pp_meta ppf "<-- non-deterministic [skip]\n"
   | `Comment s        -> pp_meta ppf "%s\n" s
   | `Exit i           -> pp_meta ppf "--> exit %d" i
 

--- a/lib/cram.ml
+++ b/lib/cram.ml
@@ -27,7 +27,7 @@ let dump_nd ppf = function
   | `Output  -> Fmt.string ppf "`Output"
   | `False   -> Fmt.string ppf "`False"
 
-let dump_line ppf = function
+let dump_line ppf (l:line) = match l with
   | `Output s         -> Fmt.pf ppf "`Output %S\n" s
   | `Part s           -> Fmt.pf ppf "`Part %S\n" s
   | `Command c        -> Fmt.pf ppf "`Command %a" Fmt.(Dump.list dump_string) c
@@ -37,6 +37,8 @@ let dump_line ppf = function
   | `Comment s        -> Fmt.pf ppf "`Comment %S" s
   | `Exit i           -> Fmt.pf ppf "`Exit %d" i
 
+let dump_lines = Fmt.Dump.list dump_line
+
 let dump_test ppf t =
   Fmt.pf ppf
     "{@[part: %a;@ non_deterministic: %a;@ command: %a;@ output: %a;@ \
@@ -44,8 +46,8 @@ let dump_test ppf t =
     Fmt.(Dump.option string) t.part
     dump_nd t.non_deterministic
     Fmt.(Dump.list string) t.command
-    Fmt.(Dump.list dump_line) t.output
-    Fmt.(Dump.list dump_line) t.lines
+    dump_lines (t.output :> line list)
+    dump_lines t.lines
     t.exit_code
 
 let dump_item ppf = function
@@ -78,6 +80,7 @@ let fold (l:S.line list) =
           ) rest
       ) t
   in
+  Log.debug (fun m -> m "lines: @[%a@]" dump_lines l);
   command [] None (fun x -> x) l
 
 let parse_lexbuf l = Lexer.file l |> fold

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -23,8 +23,8 @@ let digit = ['0' - '9']
 
 rule file = parse
  | eof { [] }
- | "<-- --non-deterministic" ws* eol        { `Non_det `Output  :: file lexbuf }
- | "<-- --non-deterministic [skip]" ws* eol { `Non_det `Command :: file lexbuf }
+ | "<-- non-deterministic" ws* eol        { `Non_det `Output  :: file lexbuf }
+ | "<-- non-deterministic [skip]" ws* eol { `Non_det `Command :: file lexbuf }
  | "<--" ([^'\n']* as str) eol { err lexbuf "invalid pre-condition: %s" str }
  | "--> exit" ws+ (digit + as str) eol { `Exit (int_of_string str) :: file lexbuf }
  | "-->"  ([^'\n']* as str) eol { err lexbuf "invalid post-condition: %s" str }

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -23,10 +23,11 @@ let digit = ['0' - '9']
 
 rule file = parse
  | eof { [] }
- | "%% --non-deterministic" ws* eol        { `Non_det `Output  :: file lexbuf }
- | "%% --non-deterministic [skip]" ws* eol { `Non_det `Command :: file lexbuf }
- | "%%" ([^'\n']* as str) eol { err lexbuf "invalid pre-condition: %s" str }
- | "@@ exit" ws+ (digit + as str) eol { `Exit (int_of_string str) :: file lexbuf }
+ | "<-- --non-deterministic" ws* eol        { `Non_det `Output  :: file lexbuf }
+ | "<-- --non-deterministic [skip]" ws* eol { `Non_det `Command :: file lexbuf }
+ | "<--" ([^'\n']* as str) eol { err lexbuf "invalid pre-condition: %s" str }
+ | "--> exit" ws+ (digit + as str) eol { `Exit (int_of_string str) :: file lexbuf }
+ | "-->"  ([^'\n']* as str) eol { err lexbuf "invalid post-condition: %s" str }
  | "### " ([^'\n']* as str) eol { `Part str    :: file lexbuf }
  | "  " ws* "..." ws* eol       { `Ellipsis    :: file lexbuf }
  | "  $ " (cmd as str) eol      { `Command (commands str) :: file lexbuf }

--- a/test/exit.sh
+++ b/test/exit.sh
@@ -1,2 +1,2 @@
   $ false
-@@ exit 2
+--> exit 2

--- a/test/exit.sh.expected
+++ b/test/exit.sh.expected
@@ -1,2 +1,2 @@
   $ false
-@@ exit 1
+--> exit 1

--- a/test/jbuild
+++ b/test/jbuild
@@ -1,6 +1,6 @@
 (alias
  ((name runtest)
-  (deps (comments.sh))
+  (deps (comments.sh comments.sh.expected))
   (action (progn
            (run ${exe:../bin/main.exe} ${<})
            (diff? ${<}.expected ${<}.corrected)))))
@@ -14,7 +14,7 @@
 
 (alias
  ((name runtest)
-  (deps (exit.sh))
+  (deps (exit.sh exit.sh.expected))
   (action (progn
            (run ${exe:../bin/main.exe} ${<})
            (diff? ${<}.expected ${<}.corrected)))))

--- a/test/jbuild
+++ b/test/jbuild
@@ -18,3 +18,10 @@
   (action (progn
            (run ${exe:../bin/main.exe} ${<})
            (diff? ${<}.expected ${<}.corrected)))))
+
+(alias
+ ((name runtest)
+  (deps (nd.sh))
+  (action (progn
+           (run ${exe:../bin/main.exe} ${<})
+           (diff? ${<} ${<}.corrected)))))

--- a/test/nd.sh
+++ b/test/nd.sh
@@ -1,3 +1,3 @@
-<-- --non-deterministic
+<-- non-deterministic
   $ echo $RANDOM % 10 + 1 | bc
   6

--- a/test/nd.sh
+++ b/test/nd.sh
@@ -1,0 +1,3 @@
+<-- --non-deterministic
+  $ echo $RANDOM % 10 + 1 | bc
+  6


### PR DESCRIPTION
Previously it was:

```
%% --foo
  $ <command>
  <output>
@@ bar
```

Now it is:
```
<-- foo
  $ <command>
  <output>
--> bar
```